### PR TITLE
Weight allocation of simulated passengers by origin outflow

### DIFF
--- a/simulator/config.py
+++ b/simulator/config.py
@@ -3,11 +3,11 @@ import os
 if 'MONGO_URI' in os.environ:
         mongo_uri = os.environ['MONGO_URI']
 else:
-        mongo_uri="mongodb://10.0.0.175:27017"
+        mongo_uri="mongodb://localhost:27017"
 
 
 if 'MONGO_DB' in os.environ:
         mongo_db_name = os.environ['MONGO_DB']
 else:
-        mongo_db_name="grits-net-meteor"
- 
+        mongo_db_name="grits"
+


### PR DESCRIPTION
Andrew want's to test this before it is deployed, so it's not safe to merge yet, but I consider the code complete.

This also changes the default db host to "localhost" so it doesn't need to be changed when testing locally, and it changes the default db name in simulator/config.py to grits so it is consistent with server.py. @frosario We will need to be sure we've defined env vars for these variables before our next deployment.
